### PR TITLE
The BasePlus package [ver. 1.35.0]

### DIFF
--- a/packages/baseplus.md
+++ b/packages/baseplus.md
@@ -47,7 +47,7 @@
   * [`%unzipLibrary()` macro](#unziplibrary-macro)
   * [`%zipArch()` macro](#ziparch-macro)
   * [`%unzipArch()` macro](#unziparch-macro)
-  * [`%findDSwithVarVal()` macro](#finddswithvarval-macro)
+  * [`%downloadFilesTo()` macro](#downloadfilesto-macro)
   * [`%LDSN()` macro](#ldsn-macro)
   * [`%LDsNm()` macro](#ldsnm-macro)
   * [`%LVarNm()` macro](#lvarnm-macro)


### PR DESCRIPTION
The BasePlus package [ver. 1.35.0]

New `%downloadFilesTo()` macro added.
Macro allows conveniently download data from internet or local locations to a directory pointed by user.

Documentation updated.

---

SHA256 digest for BasePlus: `F*62344EAA8C0DD95CCB164B5C7A91B33865B3D19CD5A2A3EDAC4C31E0541D04C9`