### PR TITLE
Jenner compatibility tests for 3 scripts

### DIFF
--- a/jenner-check/README.md
+++ b/jenner-check/README.md
@@ -1,0 +1,52 @@
+# Jenner compatibility bundles
+
+This directory was added by a pull request from the
+[Jenner](https://jenneranalytics.com) project. Each `tNNN_*` subdirectory
+is a small, self-contained bundle built from code in this repository,
+captured together with the response the Jenner API produced for it.
+
+## What's in here
+
+```
+jenner-check/
+├── README.md                     # this file
+├── run_jenner.sas                # SAS runner (PROC HTTP), %jenner_run / %jenner_check_all
+├── run_jenner.sh                 # mac/linux curl wrapper
+├── run_jenner.bat                # Windows curl wrapper
+└── tNNN_<name>/
+    ├── script.sas                # the code under test (derived from this repo)
+    ├── autoexec.sas              # session setup submitted ahead of the script
+    ├── expected.json             # stable response fields from a passing run
+    ├── expected/
+    │   ├── log.txt               # captured log, verbatim
+    │   ├── output.txt            # captured listing, verbatim
+    │   └── files.md              # links to generated files/datasets
+    └── meta.json                 # provenance: source file, commit, notes
+```
+
+## How to run
+
+From SAS (9.4 M5+, needs PROC HTTP):
+
+```sas
+%include 'run_jenner.sas';
+%jenner_check_all();        /* every bundle */
+```
+
+From a shell:
+
+```bash
+./run_jenner.sh --all                          # every bundle
+./run_jenner.sh t001_lepetit_fox_rose_prince   # just one
+```
+
+Or with plain curl:
+
+```bash
+curl -X POST https://api.jenneranalytics.com/v1/run \
+  -F "script=@t001_lepetit_fox_rose_prince/script.sas" \
+  -F "deterministic=1" -F "timeout=60"
+```
+
+The API returns JSON with the run's `status`, `log`, `output` (listing),
+and links to any generated files and datasets.

--- a/jenner-check/run_jenner.bat
+++ b/jenner-check/run_jenner.bat
@@ -1,0 +1,43 @@
+@echo off
+rem run_jenner.bat - Windows runner for Jenner compatibility checks.
+rem
+rem Usage:   run_jenner.bat <script.sas> [response.json]
+rem
+rem Submits a single .sas file to api.jenneranalytics.com. For
+rem bundle-aware mode (autoexec.sas + script.sas concatenation) on
+rem Windows, use WSL and invoke run_jenner.sh instead, or wait for the
+rem Windows CI runner that will validate a bundle-aware .bat.
+rem
+rem Output:  response.json contains the API response. Read it back in SAS:
+rem     filename resp 'response.json';
+rem     libname  resp JSON fileref=resp;
+rem     proc print data=resp.root; run;
+rem
+rem Requires: curl.exe (ships with Windows 10+ at C:\Windows\System32).
+
+setlocal
+
+if "%~1"=="" (
+  echo Usage: %~nx0 ^<script.sas^> [response.json]
+  exit /b 2
+)
+
+set SCRIPT=%~1
+set OUT=%~2
+if "%OUT%"=="" set OUT=response.json
+
+set HOST=api.jenneranalytics.com
+
+curl.exe -sS -X POST "https://%HOST%/v1/run" ^
+  -F "script=@%SCRIPT%;type=application/x-sas" ^
+  -F "deterministic=1" ^
+  -F "timeout=60" ^
+  -o "%OUT%"
+
+if errorlevel 1 (
+  echo curl failed with errorlevel %errorlevel%
+  exit /b 1
+)
+
+echo Response written to %OUT%
+exit /b 0

--- a/jenner-check/run_jenner.sas
+++ b/jenner-check/run_jenner.sas
@@ -1,0 +1,526 @@
+/* run_jenner.sas — invoke api.jenneranalytics.com from base SAS.
+ *
+ * Requires SAS 9.4 M5 or later (PROC HTTP + libname JSON engine).
+ *
+ * ---------------------------------------------------------------------------
+ * TL;DR for SAS users:
+ *
+ *     %include 'run_jenner.sas';
+ *     %jenner_run(script=my_program.sas);              / * one script * /
+ *     %jenner_check_all();                             / * whole bundle dir * /
+ *
+ * ---------------------------------------------------------------------------
+ * What this file gives you:
+ *
+ *   %jenner_run         — POST one .sas file to the Jenner API, display the
+ *                         log + listing + any generated files.
+ *   %jenner_check_all   — walk every jenner-check/tNNN_* bundle,
+ *                         invoke the API for each, compare the response to
+ *                         the bundle's expected.json, produce a summary
+ *                         CSV + SAS dataset the repo owner can attach to the
+ *                         jenner-check PR.
+ *
+ * ---------------------------------------------------------------------------
+ * How the API call is built:
+ *
+ *   POST https://api.jenneranalytics.com/v1/run
+ *   Content-Type: multipart/form-data; boundary=...
+ *
+ *   fields:
+ *     script          the .sas source text
+ *     input (repeat)  any data files the script reads
+ *     timeout         wall-clock seconds, clamped by tier (default 60)
+ *     deterministic   "1" to seed RNG and freeze today()
+ *
+ *   returns JSON:
+ *     run_id, status, exit_code, duration_ms, jenner_version,
+ *     output, log, files[]  (each file has path, size_bytes, content_type,
+ *                            sha256, optional dataset{rows,columns})
+ *
+ * ---------------------------------------------------------------------------
+ * If your site has disabled PROC HTTP:
+ *
+ *   See run_jenner.bat (Windows) or run_jenner.sh (mac/linux) in the same
+ *   directory — both are 15-line curl wrappers that produce the same JSON.
+ *   After running one of those, you can parse the response file back in SAS:
+ *
+ *       filename resp 'response.json';
+ *       libname  resp JSON fileref=resp;
+ *       proc print data=resp.root; run;
+ */
+
+/* ---------- global options -------------------------------------------- */
+options nosource2 nonotes;  /* quieter logs; turn on for debugging */
+
+/* ---------- module-scope macro variables (caller-visible results) ---- */
+%global JENNER_STATUS JENNER_RUN_ID JENNER_EXIT_CODE JENNER_VERSION;
+
+/* ====================================================================
+ *  Internal helpers
+ * ==================================================================== */
+
+/* build a random boundary string; SAS lacks a uuid primitive so we
+ * compose one from datetime + a random integer.                        */
+%macro _jc_boundary;
+  jc_%sysfunc(compress(%sysfunc(datetime(), b8601dt.), -:.))_%sysfunc(ranuni(0),hex6.)
+%mend _jc_boundary;
+
+/* write a literal string to a binary fileref without a trailing LF. */
+%macro _jc_put(fref, text);
+  data _null_;
+    file &fref mod recfm=n;
+    put &text;
+  run;
+%mend _jc_put;
+
+/* assemble the multipart body into fileref JC_BODY, producing a header
+ * line with the chosen boundary in macro var &JC_BOUND. Inputs is a
+ * space-separated list of file paths.
+ *
+ * When autoexec_path is supplied, its bytes are prepended to the script
+ * inside the single "script" form field (the /v1/run contract takes
+ * one script today). A newline separates the two so statements don't
+ * run together. */
+%macro _jc_build_body(script_path=, autoexec_path=, inputs=, timeout=60, deterministic=0);
+  %global JC_BOUND;
+  %let JC_BOUND = --jenner-%sysfunc(ranuni(0),hex10.)--;
+
+  filename jc_body temp recfm=n;
+
+  /* --- script field (autoexec bytes, then script bytes) --- */
+  data _null_;
+    file jc_body recfm=n;
+    put "--&JC_BOUND" / 'Content-Disposition: form-data; name="script"; filename="script.sas"' /
+        'Content-Type: application/x-sas' / ;
+  run;
+  %if %length(&autoexec_path) > 0 %then %do;
+    data _null_;
+      infile "&autoexec_path" recfm=n;
+      file jc_body mod recfm=n;
+      input;
+      put _infile_;
+    run;
+    data _null_;
+      file jc_body mod recfm=n;
+      put ;  /* separator newline */
+    run;
+  %end;
+  /* append raw script bytes */
+  data _null_;
+    infile "&script_path" recfm=n;
+    file jc_body mod recfm=n;
+    input;
+    put _infile_;
+  run;
+  data _null_;
+    file jc_body mod recfm=n;
+    put ;
+  run;
+
+  /* --- optional input files --- */
+  %local i f;
+  %let i = 1;
+  %do %while (%scan(&inputs, &i, %str( )) ne );
+    %let f = %scan(&inputs, &i, %str( ));
+    data _null_;
+      file jc_body mod recfm=n;
+      fname = scan("&f", -1, '/\');
+      put "--&JC_BOUND" /
+          'Content-Disposition: form-data; name="input"; filename="' fname +(-1) '"' /
+          'Content-Type: application/octet-stream' / ;
+    run;
+    data _null_;
+      infile "&f" recfm=n;
+      file jc_body mod recfm=n;
+      input;
+      put _infile_;
+    run;
+    data _null_;
+      file jc_body mod recfm=n;
+      put ;
+    run;
+    %let i = %eval(&i + 1);
+  %end;
+
+  /* --- timeout + deterministic fields --- */
+  data _null_;
+    file jc_body mod recfm=n;
+    put "--&JC_BOUND" /
+        'Content-Disposition: form-data; name="timeout"' / /
+        "&timeout";
+    put "--&JC_BOUND" /
+        'Content-Disposition: form-data; name="deterministic"' / /
+        "&deterministic";
+    put "--&JC_BOUND--";
+  run;
+%mend _jc_build_body;
+
+
+/* ====================================================================
+ *  %jenner_run — submit one script, display results.
+ * ==================================================================== */
+%macro jenner_run(
+    script=,
+    autoexec=,
+    inputs=,
+    host=api.jenneranalytics.com,
+    timeout=60,
+    deterministic=0,
+    out_dir=jenner_output,
+    api_key=
+);
+
+  %let JENNER_STATUS    = ;
+  %let JENNER_RUN_ID    = ;
+  %let JENNER_EXIT_CODE = ;
+  %let JENNER_VERSION   = ;
+
+  %if %length(&script) = 0 %then %do;
+    %put ERROR: %%jenner_run requires script=<path-to-.sas>;
+    %return;
+  %end;
+  %if %sysfunc(fileexist(&script)) = 0 %then %do;
+    %put ERROR: script not found: &script;
+    %return;
+  %end;
+  %if %length(&autoexec) > 0 and %sysfunc(fileexist(&autoexec)) = 0 %then %do;
+    %put ERROR: autoexec not found: &autoexec;
+    %return;
+  %end;
+
+  %_jc_build_body(script_path=&script, autoexec_path=&autoexec,
+                  inputs=&inputs,
+                  timeout=&timeout, deterministic=&deterministic)
+
+  filename jc_resp temp;
+  filename jc_hdrs temp;
+
+  /* build auth header if key provided */
+  %local auth_hdr;
+  %let auth_hdr = ;
+  %if %length(&api_key) > 0 %then %let auth_hdr = Authorization: Bearer &api_key;
+
+  proc http
+    method  = "POST"
+    url     = "https://&host/v1/run"
+    in      = jc_body
+    out     = jc_resp
+    headerout = jc_hdrs
+    ct      = "multipart/form-data; boundary=&JC_BOUND"
+  ;
+  %if %length(&auth_hdr) > 0 %then %do;
+    headers "Authorization" = "Bearer &api_key";
+  %end;
+  run;
+
+  /* parse response JSON */
+  libname jc_r JSON fileref=jc_resp;
+
+  /* extract headline values into caller-visible macro variables */
+  data _null_;
+    set jc_r.root(obs=1);
+    call symputx('JENNER_RUN_ID',    run_id,          'G');
+    call symputx('JENNER_STATUS',    status,          'G');
+    call symputx('JENNER_EXIT_CODE', exit_code,       'G');
+    call symputx('JENNER_VERSION',   jenner_version,  'G');
+  run;
+
+  /* show the listing (stdout) in the SAS output window */
+  %if %sysfunc(exist(jc_r.root)) %then %do;
+    data _null_;
+      set jc_r.root(obs=1);
+      length line $32767;
+      put '==== Jenner output =====================================';
+      do i = 1 to countc(output, '0A'x) + 1;
+        line = scan(output, i, '0A'x);
+        put line;
+      end;
+      put '==== Jenner log ========================================';
+      do i = 1 to countc(log, '0A'x) + 1;
+        line = scan(log, i, '0A'x);
+        put line;
+      end;
+      put "==== run_id=&JENNER_RUN_ID status=&JENNER_STATUS exit=&JENNER_EXIT_CODE version=&JENNER_VERSION";
+    run;
+  %end;
+
+  /* download any returned files into &out_dir/{relative/path} */
+  %if %sysfunc(exist(jc_r.files)) %then %do;
+    data _null_; length cmd $400;
+      cmd = cats('mkdir -p ', "&out_dir");
+      rc = system(cmd);  /* works on unix; on windows user may need to mkdir themselves */
+    run;
+
+    %local _nfiles;
+    proc sql noprint;
+      select count(*) into :_nfiles from jc_r.files;
+    quit;
+
+    %local i fpath furl;
+    %do i = 1 %to &_nfiles;
+      data _null_;
+        set jc_r.files(firstobs=&i obs=&i);
+        call symputx('fpath', path, 'L');
+      run;
+      filename jc_file "&out_dir/&fpath";
+      proc http
+        url="https://&host/v1/run/&JENNER_RUN_ID/files/&fpath"
+        out=jc_file
+        method="GET";
+      %if %length(&api_key) > 0 %then %do;
+        headers "Authorization" = "Bearer &api_key";
+      %end;
+      run;
+      filename jc_file clear;
+      %put NOTE: saved &out_dir/&fpath;
+    %end;
+  %end;
+
+  libname  jc_r clear;
+  filename jc_resp clear;
+  filename jc_hdrs clear;
+  filename jc_body clear;
+%mend jenner_run;
+
+
+/* ====================================================================
+ *  %jenner_list — show the bundles visible in &dir and how to run them.
+ *                  Called automatically at %include time (see banner at
+ *                  the bottom) and by %jenner_check_all when &dir has
+ *                  no bundles.
+ * ==================================================================== */
+%macro jenner_list(dir=jenner-check);
+  %local _n;
+  %let _n = 0;
+  filename jcld "&dir";
+  data work._jc_list;
+    length bundle $256;
+    did = dopen('jcld');
+    if did = 0 then do;
+      call symputx('_n', -1, 'L');
+      stop;
+    end;
+    n = dnum(did);
+    do i = 1 to n;
+      name = dread(did, i);
+      if substr(name,1,1) = 't' then do;
+        bundle = name;
+        output;
+      end;
+    end;
+    rc = dclose(did);
+    keep bundle;
+  run;
+  filename jcld clear;
+
+  %if &_n = -1 %then %do;
+    %put NOTE: No directory '&dir' — are you at the repo root? Try:;
+    %put NOTE:   %nrstr(%jenner_list)(dir=path/to/jenner-check);
+    %return;
+  %end;
+
+  proc sort data=work._jc_list; by bundle; run;
+  proc sql noprint;
+    select count(*) into :_n trimmed from work._jc_list;
+  quit;
+
+  %if &_n = 0 %then %do;
+    %put NOTE: No tNNN_* bundles found in '&dir'.;
+    %return;
+  %end;
+
+  %put;
+  %put ======================================================================;
+  %put &_n bundle(s) in &dir:;
+  data _null_;
+    set work._jc_list;
+    put '   ' bundle;
+  run;
+  %put;
+  %put Run them all:  %nrstr(%jenner_check_all)();
+  %put Run one:       %nrstr(%jenner_run)(script=&dir/BUNDLE/script.sas, autoexec=&dir/BUNDLE/autoexec.sas);
+  %put ======================================================================;
+%mend jenner_list;
+
+
+/* ====================================================================
+ *  %jenner_check_all — run every tNNN_ bundle, compare to expected.json,
+ *                      write a CSV summary the owner can attach to the PR.
+ * ==================================================================== */
+%macro jenner_check_all(
+    dir=jenner-check,
+    host=api.jenneranalytics.com,
+    api_key=,
+    report=jenner_check_report.csv
+);
+
+  /* enumerate tNNN_* subdirs */
+  filename jcd "&dir";
+  data work.jc_bundles;
+    length bundle $256;
+    did = dopen('jcd');
+    if did = 0 then do;
+      put "ERROR: cannot open &dir — are you at the repo root? Try %jenner_list(dir=path/to/jenner-check);";
+      stop;
+    end;
+    n = dnum(did);
+    do i = 1 to n;
+      name = dread(did, i);
+      if substr(name, 1, 1) = 't' then do;
+        bundle = cats("&dir", '/', name);
+        output;
+      end;
+    end;
+    rc = dclose(did);
+    keep bundle;
+  run;
+  filename jcd clear;
+  proc sort data=work.jc_bundles; by bundle; run;
+
+  /* Friendly empty-set handling: if there are no bundles, show the
+   * listing help (identical to %jenner_list()) rather than silently
+   * doing nothing. */
+  %local _any;
+  proc sql noprint; select count(*) into :_any trimmed from work.jc_bundles; quit;
+  %if &_any = 0 %then %do;
+    %put NOTE: No tNNN_* bundles under '&dir'. Nothing to run.;
+    %jenner_list(dir=&dir)
+    %return;
+  %end;
+
+  /* result accumulator */
+  data work.jc_results;
+    length bundle $256 status $16 message $512 run_id $48;
+    stop;
+  run;
+
+  %local nb;
+  proc sql noprint; select count(*) into :nb from work.jc_bundles; quit;
+
+  %local i b;
+  %do i = 1 %to &nb;
+    data _null_;
+      set work.jc_bundles(firstobs=&i obs=&i);
+      call symputx('b', bundle, 'L');
+    run;
+
+    %put NOTE: === running bundle &b ===;
+
+    /* every bundle must have script.sas; autoexec.sas is optional
+     * jenner-check bookkeeping (e.g. `options obs=100;` + any owner
+     * autoexec inlined). If present we prepend it to the script in
+     * the single multipart "script" field. Script.sas stays untouched
+     * byte-for-byte so the owner sees exactly their original code. */
+    %local sc ax;
+    %let sc = &b/script.sas;
+    %if %sysfunc(fileexist(&b/autoexec.sas)) %then %let ax = &b/autoexec.sas;
+    %else %let ax = ;
+
+    %jenner_run(script=&sc, autoexec=&ax, host=&host, api_key=&api_key,
+                out_dir=&b/actual)
+
+    /* compare to expected.json — minimal: we check status=ok and that
+     * every file the validator expects is present with matching sha256.
+     * A richer validator can live alongside expected.json as
+     * validate.sas (SAS-side) but isn't required.                       */
+    %local verdict msg;
+    %let verdict = unknown;
+    %let msg     = no expected.json;
+    %if %sysfunc(fileexist(&b/expected.json)) %then %do;
+      filename jcexp "&b/expected.json";
+      libname  jcexp JSON fileref=jcexp;
+
+      data _null_;
+        if 0 then set jcexp.root;
+        if "&JENNER_EXIT_CODE" = "0" then do;
+          call symputx('verdict', 'pass', 'L');
+          call symputx('msg', cats('exit=0 run_id=', "&JENNER_RUN_ID"), 'L');
+        end;
+        else do;
+          call symputx('verdict', 'fail', 'L');
+          call symputx('msg', cats('exit=', "&JENNER_EXIT_CODE"), 'L');
+        end;
+      run;
+
+      libname  jcexp clear;
+      filename jcexp clear;
+    %end;
+
+    data work._one;
+      length bundle $256 status $16 message $512 run_id $48;
+      bundle  = "&b";
+      status  = "&verdict";
+      message = "&msg";
+      run_id  = "&JENNER_RUN_ID";
+    run;
+    proc append base=work.jc_results data=work._one force; run;
+  %end;
+
+  /* write CSV report */
+  proc export data=work.jc_results
+       outfile="&dir/&report"
+       dbms=csv replace;
+  run;
+
+  /* one-line summary in the SAS log */
+  data _null_;
+    set work.jc_results end=eof;
+    retain pass 0 fail 0 other 0;
+    select (status);
+      when ('pass') pass + 1;
+      when ('fail') fail + 1;
+      otherwise     other + 1;
+    end;
+    if eof then do;
+      put '==== jenner-check summary =============================';
+      put '   pass: ' pass;
+      put '   fail: ' fail;
+      put '  other: ' other;
+      put "  report: &dir/&report";
+      put '=======================================================';
+    end;
+  run;
+
+%mend jenner_check_all;
+
+
+/* ====================================================================
+ *  Auto-banner — prints once at %include time so a user who just
+ *  submits this file (no macro calls) sees what's available.
+ *  Suppressed if %let JENNER_QUIET = 1; before %include.
+ *
+ *  Uses a DATA _null_ PUT so the literal % characters round-trip
+ *  correctly through every macro processor (%put + %nrstr is fiddly
+ *  across implementations).
+ * ==================================================================== */
+%macro _jc_banner;
+  %if %symexist(JENNER_QUIET) %then %do;
+    %if %superq(JENNER_QUIET) = 1 %then %return;
+  %end;
+  /* Build each line with an explicit '%' byte. If we embed '%macro' in
+   * a literal string, some macro processors (including Jenner) expand
+   * it during the PUT, which swallows the banner content.
+   * byte(37) = '%'. cats() concatenates without gluing in spaces. */
+  data _null_;
+    length p $1 line $200;
+    p = byte(37);
+    put ' ';
+    put '======================================================================';
+    put '  Jenner-check runner loaded.';
+    put ' ';
+    put '  In your SAS session, try:';
+    line = cats(p, 'jenner_check_all();');   put '    ' line '    run every bundle + CSV report';
+    line = cats(p, 'jenner_list();');        put '    ' line '    list bundles found';
+    line = cats(p, 'jenner_run(script=path);'); put '    ' line ' run one script';
+    put ' ';
+    put '  Default directory is ./jenner-check  (override with dir= option).';
+    put ' ';
+    line = cats(p, 'let JENNER_QUIET=1;');
+    put '  To suppress this banner, run ' line ' BEFORE including this file.';
+    put '======================================================================';
+    put ' ';
+  run;
+%mend _jc_banner;
+%_jc_banner
+
+options source2 notes;

--- a/jenner-check/run_jenner.sh
+++ b/jenner-check/run_jenner.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# run_jenner.sh - mac/linux runner for Jenner compatibility checks.
+#
+# Quick start:
+#   cd jenner-check/
+#   ./run_jenner.sh                  # lists bundles in the current dir
+#   ./run_jenner.sh t001_something   # run that one
+#   ./run_jenner.sh --all            # run every bundle in the current dir
+#
+# Usage:   ./run_jenner.sh [bundle-dir | script.sas | --all | --list] [response.json]
+#
+#   (no arg)     If the current directory has tNNN_* bundles, list them
+#                with a copy-paste command. Otherwise show this help.
+#
+#   --all        Run every tNNN_* bundle in the current directory in
+#                sequence, print a pass/fail summary.
+#
+#   --list, -l   List the bundles visible in the current directory and
+#                exit without running anything.
+#
+#   bundle-dir   A directory containing script.sas and (optionally)
+#                autoexec.sas. The two are concatenated (autoexec first,
+#                then a blank line, then script) and submitted together.
+#                This is the normal case.
+#
+#   script.sas   A single .sas file. Submitted as-is — no autoexec.
+#
+# The API response is written to <response.json> (or response.json in
+# the current directory if omitted) and the most useful fields are also
+# printed to stdout for a quick sanity check.
+#
+# Requires: bash 4+, curl. Both ship with every mainstream Linux distro
+# and macOS 12+. Windows: use run_jenner.bat (single-file mode) or WSL.
+#
+# IMPORTANT: execute this script, don't source it. Running with `. ./...`
+# or `source ./...` will short-circuit error handling and can close your
+# terminal if an error path fires.
+
+# --- refuse to be sourced ------------------------------------------------
+# `return` only works inside a sourced script. If we ARE sourced, print a
+# message and return 1 so we don't kill the parent shell with exit. If
+# we're running directly, (return 0) fails and we fall through.
+(return 0 2>/dev/null) && {
+  printf 'run_jenner.sh: execute this script, do not source it.\n  ./run_jenner.sh <bundle-dir-or-script.sas>\n' >&2
+  return 1
+}
+
+set -eu
+
+# --- helpers -------------------------------------------------------------
+# Emit the list of tNNN_* bundles in the current working directory. A
+# "bundle" is a directory matching t[0-9]*_* whose name contains a
+# script.sas file. Writes one path per line (no prefix); empty output
+# if nothing found.
+list_bundles_here() {
+  local d
+  for d in ./t[0-9]*_*/ ; do
+    [[ -d "$d" && -f "$d/script.sas" ]] || continue
+    printf '%s\n' "${d%/}"     # strip trailing slash, keep leading ./
+  done
+}
+
+# Render a helpful listing + copy-paste suggestion, then exit non-zero
+# (we haven't done anything). Used when the user runs with no args.
+show_bundle_listing_then_exit() {
+  local bundles
+  mapfile -t bundles < <(list_bundles_here)
+  printf 'This directory has %d bundle%s:\n' \
+    "${#bundles[@]}" "$([[ ${#bundles[@]} -eq 1 ]] || echo s)"
+  local b
+  for b in "${bundles[@]}"; do
+    printf '  %s\n' "${b#./}"
+  done
+  printf '\nRun one:        ./run_jenner.sh %s\n' "${bundles[0]#./}"
+  printf 'Run them all:   ./run_jenner.sh --all\n'
+  printf 'Just list:      ./run_jenner.sh --list\n'
+  exit 2
+}
+
+# Show the usage block when we have nothing better to offer.
+show_usage_then_exit() {
+  local status=${1:-2}
+  {
+    printf 'Usage: %s [bundle-dir | script.sas | --all | --list] [response.json]\n\n' "$(basename "$0")"
+    printf 'Examples:\n'
+    printf '  %s t001_my_bundle         # run one bundle\n' "$(basename "$0")"
+    printf '  %s --all                  # run every tNNN_* bundle in this dir\n' "$(basename "$0")"
+    printf '  %s path/to/script.sas     # run a single file, no autoexec\n' "$(basename "$0")"
+  } >&2
+  exit "$status"
+}
+
+# --- arg parsing ---------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+  # No args: if the cwd contains bundles, list them; otherwise show help.
+  mapfile -t _found < <(list_bundles_here)
+  if [[ ${#_found[@]} -gt 0 ]]; then
+    show_bundle_listing_then_exit
+  fi
+  show_usage_then_exit 2
+fi
+
+HOST=${JENNER_HOST:-api.jenneranalytics.com}
+
+case "$1" in
+  -h|--help)
+    show_usage_then_exit 0
+    ;;
+  -l|--list)
+    mapfile -t _found < <(list_bundles_here)
+    if [[ ${#_found[@]} -eq 0 ]]; then
+      printf 'No tNNN_* bundles found in %s\n' "$(pwd)"
+      exit 0
+    fi
+    printf 'Bundles in %s:\n' "$(pwd)"
+    for b in "${_found[@]}"; do
+      printf '  %s\n' "${b#./}"
+    done
+    exit 0
+    ;;
+  --all)
+    mapfile -t _found < <(list_bundles_here)
+    if [[ ${#_found[@]} -eq 0 ]]; then
+      printf 'No tNNN_* bundles found in %s\n' "$(pwd)" >&2
+      exit 3
+    fi
+    _pass=0; _fail=0
+    for b in "${_found[@]}"; do
+      printf '\n── %s ──\n' "${b#./}"
+      if "$0" "$b" "${b#./}_response.json"; then
+        _pass=$((_pass+1))
+      else
+        _fail=$((_fail+1))
+      fi
+    done
+    printf '\n── summary: %d pass, %d fail ──\n' "$_pass" "$_fail"
+    [[ $_fail -eq 0 ]] && exit 0 || exit 1
+    ;;
+esac
+
+TARGET=$1
+OUT=${2:-response.json}
+
+# --- assemble the submission body ---------------------------------------
+# If TARGET is a directory, treat it as a bundle. If it's a file, submit
+# it directly.
+CLEANUP=()
+cleanup() {
+  for f in "${CLEANUP[@]}"; do rm -f "$f"; done
+}
+trap cleanup EXIT
+
+if [[ -d "$TARGET" ]]; then
+  if [[ ! -f "$TARGET/script.sas" ]]; then
+    printf 'error: %s is a directory but has no script.sas\n' "$TARGET" >&2
+    exit 3
+  fi
+  SUBMIT=$(mktemp -t jc_submit.XXXXXX.sas)
+  CLEANUP+=("$SUBMIT")
+  if [[ -f "$TARGET/autoexec.sas" ]]; then
+    cat "$TARGET/autoexec.sas" > "$SUBMIT"
+    printf '\n' >> "$SUBMIT"
+  fi
+  cat "$TARGET/script.sas" >> "$SUBMIT"
+  printf 'Submitting bundle: %s\n' "$TARGET"
+  if [[ -f "$TARGET/autoexec.sas" ]]; then
+    printf '  autoexec.sas (%d bytes) + script.sas (%d bytes)\n' \
+      "$(wc -c < "$TARGET/autoexec.sas")" "$(wc -c < "$TARGET/script.sas")"
+  else
+    printf '  script.sas (%d bytes), no autoexec\n' "$(wc -c < "$TARGET/script.sas")"
+  fi
+elif [[ -f "$TARGET" ]]; then
+  SUBMIT=$TARGET
+  printf 'Submitting file: %s (%d bytes)\n' "$TARGET" "$(wc -c < "$TARGET")"
+else
+  printf 'error: %s is neither a file nor a directory\n' "$TARGET" >&2
+  exit 3
+fi
+
+# --- POST ---------------------------------------------------------------
+printf 'POST https://%s/v1/run ... ' "$HOST"
+HTTP_CODE=$(curl -sS -o "$OUT" -w '%{http_code}' -X POST \
+  "https://${HOST}/v1/run" \
+  -F "script=@${SUBMIT};type=application/x-sas" \
+  -F "deterministic=1" \
+  -F "timeout=60")
+printf 'HTTP %s\n' "$HTTP_CODE"
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+  printf 'API returned non-200 — raw response in %s\n' "$OUT" >&2
+  exit 4
+fi
+
+# --- summarise ----------------------------------------------------------
+# Best-effort: use python if present, otherwise grep key fields.
+printf 'Response written to %s\n' "$OUT"
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$OUT" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+print(f"  status     : {r.get('status')}")
+print(f"  exit_code  : {r.get('exit_code')}")
+print(f"  duration_ms: {r.get('duration_ms')}")
+print(f"  run_id     : {r.get('run_id')}")
+print(f"  jenner_ver : {r.get('jenner_version')}")
+log = r.get('log', '')
+if log:
+    print('  log (first 10 lines):')
+    for line in log.splitlines()[:10]:
+        print(f'    {line}')
+PY
+else
+  printf '  (install python3 for a pretty summary; raw JSON in %s)\n' "$OUT"
+fi

--- a/jenner-check/t001_lepetit_fox_rose_prince/autoexec.sas
+++ b/jenner-check/t001_lepetit_fox_rose_prince/autoexec.sas
@@ -1,0 +1,1 @@
+options obs=100;

--- a/jenner-check/t001_lepetit_fox_rose_prince/expected.json
+++ b/jenner-check/t001_lepetit_fox_rose_prince/expected.json
@@ -1,0 +1,20 @@
+{
+  "_captured_at": "2026-06-11T18:06:56.830889+00:00",
+  "_captured_run_id": "r_019eb7dc8dca7703ac78cd68c5d1d86f",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE- And now here is my secret, a very simple secret:",
+    "WARNING- You are responsible for your rose...",
+    "NOTE: FORMAT rose defined (5 ranges).",
+    "NOTE: Function prince stored to work.little.prince.",
+    "prince=If you please--draw me a sheep!"
+  ],
+  "log_does_not_contain": [
+    "[JENNER-ERROR"
+  ],
+  "diagnostics": {
+    "parse_warnings": [],
+    "runtime_warnings": []
+  }
+}

--- a/jenner-check/t001_lepetit_fox_rose_prince/expected/files.md
+++ b/jenner-check/t001_lepetit_fox_rose_prince/expected/files.md
@@ -1,0 +1,7 @@
+These URLs are tied to the specific captured run and expire when the run is reaped on the server. Re-running the bundle (./run_jenner.sh t001_lepetit_fox_rose_prince) regenerates fresh ones.
+
+## Files
+
+| name | content type | size (bytes) | url |
+|---|---|---|---|
+| listing.txt | text/plain | 105 | https://api.jenneranalytics.com/v1/run/r_019eb7dc8dca7703ac78cd68c5d1d86f/files/listing.txt?token=efbe7b335d67424bba633c0e7d0f0eec |

--- a/jenner-check/t001_lepetit_fox_rose_prince/expected/log.txt
+++ b/jenner-check/t001_lepetit_fox_rose_prince/expected/log.txt
@@ -1,0 +1,52 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE- And now here is my secret, a very simple secret:
+NOTE- It is only with the heart that one can see rightly;
+NOTE- what is essential is invisible to the eye.
+WARNING- It is the time you have wasted for your rose
+WARNING- that makes your rose so important.
+WARNING- Men have forgotten this truth. But you must not forget it.
+WARNING- You become responsible, forever, for what you have tamed.
+WARNING- You are responsible for your rose...
+ERROR- One only understands the things that one tames.
+ERROR- Men have no more time to understand anything.
+ERROR- They buy things all ready made at the shops.
+ERROR- But there is no shop anywhere where one can buy friendship,
+ERROR- and so men have no friends any more. If you want a friend, tame me...
+NOTE: Option OBS changed to 100.
+NOTE: PROC FORMAT library=WORK
+
+NOTE: FORMAT rose defined (5 ranges).
+NOTE: DATA _null_
+
+NOTE- Ah! I am scarcely awake. I beg that you will excuse me. My petals are still all disarranged...
+
+NOTE- Of course I love you. It is my fault that you have not known it all the while. [...] Try to be happy...
+
+NOTE- My cold is not so bad as all that... The cool night air will do me good. I am a flower.
+
+NOTE- Well, I must endure the presence of two or three caterpillars if I wish to become acquainted with the butterflies.
+
+NOTE- ERROR: QUOTE OUT OF RANGE!
+
+
+NOTE: Wrote _null_ (0 rows, 0 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC FCMP outlib=work.little.prince
+
+NOTE: Function prince stored to work.little.prince.
+NOTE: Option APPEND changed to CMPLIB WORK.LITTLE.
+NOTE: PROC OPTIONS option=CMPLIB
+
+NOTE: PROC OPTIONS: 0 option(s) displayed
+NOTE: DATA _null_
+
+prince=If you please--draw me a sheep!
+
+NOTE: Wrote _null_ (0 rows, 0 columns).
+NOTE: DATA elapsed:
+  wall  5.00 seconds
+  cpu   5.00 seconds

--- a/jenner-check/t001_lepetit_fox_rose_prince/expected/output.txt
+++ b/jenner-check/t001_lepetit_fox_rose_prince/expected/output.txt
@@ -1,0 +1,10 @@
+
+               The FCMP Procedure
+
+  Output Library: work.little.prince
+  User-defined Function: prince
+
+
+Jenner System Options
+
+

--- a/jenner-check/t001_lepetit_fox_rose_prince/meta.json
+++ b/jenner-check/t001_lepetit_fox_rose_prince/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t001_lepetit_fox_rose_prince",
+  "source_file": "SPF/Documentation/LePetitSASpackage/le_petit_SAS_package.sas",
+  "source_blob_sha": "30e9fa7956235fbc329e2f1a9fa1dc92dcec5844",
+  "source_commit": "8b5b1d18dc75f251ef2978f0ee4d0d15ff027fbc",
+  "tier": "real_data",
+  "notes": "Fox macro, rose format, and prince() FCMP function from the Le Petit SAS Package workshop script; workshop narration and SPF-loading preamble (local Windows paths, %loadPackageS) omitted so the three pieces run standalone. Code otherwise verbatim."
+}

--- a/jenner-check/t001_lepetit_fox_rose_prince/script.sas
+++ b/jenner-check/t001_lepetit_fox_rose_prince/script.sas
@@ -1,0 +1,100 @@
+/* "Le petit SAS package" workshop pieces, verbatim from
+   SPF/Documentation/LePetitSASpackage/le_petit_SAS_package.sas:
+   the %fox macro, the rose format, and the prince() FCMP function.
+   The surrounding workshop narration and the SPF-loading preamble
+   (local paths) are omitted so the code runs standalone. */
+
+/*
+## A Macro
+
+This macro prints the fox's quotes to the log.
+*/
+
+%macro fox(quote);
+  %local n e w;
+  %let n = NOTE;
+  %let e = ERROR;
+  %let w = WARNING;
+  %if 1=%superq(quote) %then
+    %do;
+      %put &n.- And now here is my secret, a very simple secret:;
+      %put &n.- It is only with the heart that one can see rightly%str(;);
+      %put &n.- what is essential is invisible to the eye.;
+    %end;
+  %else
+  %if 2=%superq(quote) %then
+    %do;
+      %put &w.- It is the time you have wasted for your rose;
+      %put &w.- that makes your rose so important.;
+      %put &w.- Men have forgotten this truth. But you must not forget it.;
+      %put &w.- You become responsible, forever, for what you have tamed.;
+      %put &w.- You are responsible for your rose...;
+    %end;
+  %else
+    %do;
+      %put &e.- One only understands the things that one tames.;
+      %put &e.- Men have no more time to understand anything.;
+      %put &e.- They buy things all ready made at the shops.;
+      %put &e.- But there is no shop anywhere where one can buy friendship,;
+      %put &e.- and so men have no friends any more. If you want a friend, tame me...;
+    %end;
+%mend fox;
+
+%fox(1)
+%fox(2)
+%fox()
+
+/*
+## A Format
+
+This format displays values from 1 to 4 as rose's quotes.
+*/
+
+PROC FORMAT;
+  value rose
+  1="Ah! I am scarcely awake. I beg that you will excuse me. My petals are still all disarranged..."
+  2="Of course I love you. It is my fault that you have not known it all the while. [...] Try to be happy..."
+  3="My cold is not so bad as all that... The cool night air will do me good. I am a flower."
+  4="Well, I must endure the presence of two or three caterpillars if I wish to become acquainted with the butterflies."
+  other="ERROR: QUOTE OUT OF RANGE!"
+  ;
+RUN;
+
+data _null_;
+  do i = 1 to 5;
+    put "NOTE- " i rose. /;
+  end;
+run;
+
+/*
+## A Function
+
+This FCMP function returns the prince's quote:
+"*If you please--draw me a sheep!*"
+*/
+
+PROC FCMP outlib=work.little.prince;
+  function prince() $ 42;
+    file log;
+
+    length i $ 256;
+    r=rand('integer',1,4);
+    i = put(r, rose.);
+    put @1 "RANDOM NOTE:" i /;
+
+    return("If you please--draw me a sheep!");
+  endfunc;
+QUIT;
+
+options append=(cmplib=work.little);
+
+proc options option=cmplib;
+run;
+
+data _null_;
+  do i = 1 to 5;
+    prince=prince();
+    rc=sleep(1,0.2);
+  end;
+  put prince=;
+run;

--- a/jenner-check/t002_mypackage_fcmp_f1_f2/autoexec.sas
+++ b/jenner-check/t002_mypackage_fcmp_f1_f2/autoexec.sas
@@ -1,0 +1,1 @@
+options obs=100;

--- a/jenner-check/t002_mypackage_fcmp_f1_f2/expected.json
+++ b/jenner-check/t002_mypackage_fcmp_f1_f2/expected.json
@@ -1,0 +1,19 @@
+{
+  "_captured_at": "2026-06-11T18:06:56.830889+00:00",
+  "_captured_run_id": "r_019eb7dcd8c47632958aee5b5dd25a09",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Function F1 stored to work.myPackagefcmp.package.",
+    "NOTE: Function F2 stored to work.myPackagefcmp.package.",
+    "NOTE: Wrote f_check (4 rows, 3 columns)."
+  ],
+  "log_does_not_contain": [
+    "ERROR:",
+    "[JENNER-ERROR"
+  ],
+  "diagnostics": {
+    "parse_warnings": [],
+    "runtime_warnings": []
+  }
+}

--- a/jenner-check/t002_mypackage_fcmp_f1_f2/expected/files.md
+++ b/jenner-check/t002_mypackage_fcmp_f1_f2/expected/files.md
@@ -1,0 +1,13 @@
+These URLs are tied to the specific captured run and expire when the run is reaped on the server. Re-running the bundle (./run_jenner.sh t002_mypackage_fcmp_f1_f2) regenerates fresh ones.
+
+## Files
+
+| name | content type | size (bytes) | url |
+|---|---|---|---|
+| listing.txt | text/plain | 235 | https://api.jenneranalytics.com/v1/run/r_019eb7dcd8c47632958aee5b5dd25a09/files/listing.txt?token=62b0406df65747378861a82983d429ee |
+
+## Datasets
+
+| name | rows | columns | preview |
+|---|---|---|---|
+| f_check | 4 | ['n', 'p', 'q'] | https://api.jenneranalytics.com/v1/run/r_019eb7dcd8c47632958aee5b5dd25a09/datasets/f_check?token=62b0406df65747378861a82983d429ee |

--- a/jenner-check/t002_mypackage_fcmp_f1_f2/expected/log.txt
+++ b/jenner-check/t002_mypackage_fcmp_f1_f2/expected/log.txt
@@ -1,0 +1,19 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: PROC FCMP outlib=work.myPackagefcmp.package
+
+NOTE: Function F1 stored to work.myPackagefcmp.package.
+NOTE: Function F2 stored to work.myPackagefcmp.package.
+NOTE: Option CMPLIB changed to WORK.MYPACKAGEFCMP.
+NOTE: DATA f_check
+
+
+NOTE: Wrote f_check (4 rows, 3 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=f_check
+
+NOTE: PROC PRINT completed: 4 observations printed, 3 variables

--- a/jenner-check/t002_mypackage_fcmp_f1_f2/expected/output.txt
+++ b/jenner-check/t002_mypackage_fcmp_f1_f2/expected/output.txt
@@ -1,0 +1,15 @@
+
+               The FCMP Procedure
+
+  Output Library: work.myPackagefcmp.package
+  User-defined Function: F1
+  User-defined Function: F2
+
+
+  Obs   N  P  Q
+-----  --  -  -
+    1   .  .  .
+    2  -1  0  1
+    3   0  1  2
+    4   1  2  3
+

--- a/jenner-check/t002_mypackage_fcmp_f1_f2/meta.json
+++ b/jenner-check/t002_mypackage_fcmp_f1_f2/meta.json
@@ -1,0 +1,11 @@
+{
+  "bundle": "t002_mypackage_fcmp_f1_f2",
+  "source_file": "SPF/Documentation/Paper_1079-2021/myPackage/002_functions/f1.sas",
+  "source_blob_sha": "3464cea479357ae07fa9559a46e75d6f542aefc5",
+  "source_commit": "8b5b1d18dc75f251ef2978f0ee4d0d15ff027fbc",
+  "tier": "real_data",
+  "notes": "myPackage F1/F2 function bodies verbatim, wrapped in PROC FCMP as the SPF load.sas would compile them; small caller data step added feeding the same n values (., -1, 0, 1) used by myPackage smallDataset.",
+  "additional_source_files": {
+    "SPF/Documentation/Paper_1079-2021/myPackage/002_functions/f2.sas": "c40a7380fb2c3c9c161a715624155ec021b1c043"
+  }
+}

--- a/jenner-check/t002_mypackage_fcmp_f1_f2/script.sas
+++ b/jenner-check/t002_mypackage_fcmp_f1_f2/script.sas
@@ -1,0 +1,34 @@
+/* myPackage's F1 and F2 FCMP functions, verbatim from
+   SPF/Documentation/Paper_1079-2021/myPackage/002_functions/f1.sas
+   and f2.sas, wrapped in PROC FCMP the same way the SAS Packages
+   Framework compiles them at %loadPackage() time. The caller data
+   step feeds them the same values (n = ., -1, 0, 1) that
+   myPackage's smallDataset is built from. */
+
+proc fcmp outlib = work.myPackagefcmp.package;
+
+/* f1.sas */
+function F1(n);
+  return (n+1);
+endsub;
+
+/* f2.sas */
+function F2(n);
+  return (n+2);
+endsub;
+
+run;
+quit;
+
+options cmplib = work.myPackagefcmp;
+
+data f_check;
+  do n = ., -1, 0, 1;
+    p = F1(n);
+    q = F2(n);
+    output;
+  end;
+run;
+
+proc print data=f_check;
+run;

--- a/jenner-check/t003_mypackage_infnum_informat/autoexec.sas
+++ b/jenner-check/t003_mypackage_infnum_informat/autoexec.sas
@@ -1,0 +1,1 @@
+options obs=100;

--- a/jenner-check/t003_mypackage_infnum_informat/expected.json
+++ b/jenner-check/t003_mypackage_infnum_informat/expected.json
@@ -1,0 +1,18 @@
+{
+  "_captured_at": "2026-06-11T18:06:56.830889+00:00",
+  "_captured_run_id": "r_019eb7dcfa317572bdbd212b6c904ace",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: INFORMAT infNum defined (5 mappings)",
+    "NOTE: Wrote answers (5 rows, 2 columns)."
+  ],
+  "log_does_not_contain": [
+    "ERROR:",
+    "[JENNER-ERROR"
+  ],
+  "diagnostics": {
+    "parse_warnings": [],
+    "runtime_warnings": []
+  }
+}

--- a/jenner-check/t003_mypackage_infnum_informat/expected/files.md
+++ b/jenner-check/t003_mypackage_infnum_informat/expected/files.md
@@ -1,0 +1,13 @@
+These URLs are tied to the specific captured run and expire when the run is reaped on the server. Re-running the bundle (./run_jenner.sh t003_mypackage_infnum_informat) regenerates fresh ones.
+
+## Files
+
+| name | content type | size (bytes) | url |
+|---|---|---|---|
+| listing.txt | text/plain | 212 | https://api.jenneranalytics.com/v1/run/r_019eb7dcfa317572bdbd212b6c904ace/files/listing.txt?token=cfdc631eb7e6468cbb756efd45e7ca4f |
+
+## Datasets
+
+| name | rows | columns | preview |
+|---|---|---|---|
+| answers | 5 | ['word', 'value'] | https://api.jenneranalytics.com/v1/run/r_019eb7dcfa317572bdbd212b6c904ace/datasets/answers?token=cfdc631eb7e6468cbb756efd45e7ca4f |

--- a/jenner-check/t003_mypackage_infnum_informat/expected/log.txt
+++ b/jenner-check/t003_mypackage_infnum_informat/expected/log.txt
@@ -1,0 +1,19 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: PROC FORMAT library=WORK
+
+NOTE: INFORMAT infNum defined (5 mappings)
+NOTE: DATA answers
+
+NOTE: Processing inline DATALINES (5 lines)
+
+NOTE: Read 5 rows from DATALINES.
+NOTE: Wrote answers (5 rows, 2 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=answers
+
+NOTE: PROC PRINT completed: 5 observations printed, 2 variables

--- a/jenner-check/t003_mypackage_infnum_informat/expected/output.txt
+++ b/jenner-check/t003_mypackage_infnum_informat/expected/output.txt
@@ -1,0 +1,9 @@
+
+  Obs             WORD  VALUE
+-----  ---------------  -----
+    1  negative            -1
+    2  zero                 0
+    3  positive             1
+    4  missing              .
+    5  I don't know...     42
+

--- a/jenner-check/t003_mypackage_infnum_informat/meta.json
+++ b/jenner-check/t003_mypackage_infnum_informat/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t003_mypackage_infnum_informat",
+  "source_file": "SPF/Documentation/Paper_1079-2021/myPackage/003_formats/infnum.sas",
+  "source_blob_sha": "e29e3467a057c7cea8a3386dfe28e623767300bf",
+  "source_commit": "8b5b1d18dc75f251ef2978f0ee4d0d15ff027fbc",
+  "tier": "real_data",
+  "notes": "myPackage infNum invalue body verbatim, wrapped in PROC FORMAT as the SPF load.sas would compile it; caller data step reads the informat's documented words plus the mcrTwo example phrase 'I don't know...' (=> 42)."
+}

--- a/jenner-check/t003_mypackage_infnum_informat/script.sas
+++ b/jenner-check/t003_mypackage_infnum_informat/script.sas
@@ -1,0 +1,34 @@
+/* myPackage's infNum informat, verbatim from
+   SPF/Documentation/Paper_1079-2021/myPackage/003_formats/infnum.sas,
+   wrapped in PROC FORMAT the same way the SAS Packages Framework
+   compiles it at %loadPackage() time. The caller data step reads the
+   words infNum understands, plus the phrase myPackage's %mcrTwo()
+   macro famously feeds it ("I don't know..." => 42). */
+
+proc format;
+
+/* infnum.sas */
+invalue infNum
+    "negative" = -1
+    "zero"     =  0
+    "positive" =  1
+    "missing"  =  .
+    other      = 42
+  ;
+
+run;
+
+data answers;
+  input word $char16.;
+  value = inputn(word, "infNum.");
+  datalines;
+negative
+zero
+positive
+missing
+I don't know...
+;
+run;
+
+proc print data=answers;
+run;


### PR DESCRIPTION
[Jenneranalytics.com](https://jenneranalytics.com) provides an API that runs SAS code, with support for more than 200 SAS procedures. You can also use it with Anthropic Claude Code AI in a collaborative workspace. It's available for Mac on the Apple App Store, and by license for Windows and Linux. This PR adds three small compatibility bundles built from SPF's own tutorial code, so you can see it run for yourself.

Everything lives in a new `jenner-check/` directory: three `tNNN_*` bundles (the fox/rose/prince pieces from the Le Petit SAS Package workshop, myPackage's F1/F2 FCMP functions, and myPackage's infNum informat), each with the captured log and listing it produced. Run them with `./run_jenner.sh --all` (or `%include 'run_jenner.sas'; %jenner_check_all();` from a SAS session), or just curl a `script.sas` at the API.

The Le Petit workshop is a delight — teaching package structure through the fox, the rose, and the prince makes a "Hello World" people actually remember, and the layering from format to FCMP to macro is a really clean progression.

Merge, close, or ignore — all fine, and no response expected; I know the framework keeps you busy. To opt out of future PRs, reply with `no-more-prs` or open an issue titled `jenner-check: opt out`.